### PR TITLE
Debug process cache lookup failure

### DIFF
--- a/test_process_cache.c
+++ b/test_process_cache.c
@@ -1,0 +1,63 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "userspace/linx_process_cache/include/linx_process_cache.h"
+
+void print_process_info(linx_process_info_t *info) {
+    if (!info) {
+        printf("进程信息为空\n");
+        return;
+    }
+    
+    printf("=== 进程信息 ===\n");
+    printf("PID: %d\n", info->pid);
+    printf("PPID: %d\n", info->ppid);
+    printf("PGID: %d\n", info->pgid);
+    printf("SID: %u\n", info->sid);
+    printf("UID: %u\n", info->uid);
+    printf("GID: %u\n", info->gid);
+    printf("TTY: %u\n", info->tty);
+    printf("Login UID: %u\n", info->loginuid);
+    printf("命令行参数个数: %lu\n", info->cmdnargs);
+    printf("进程名: %s\n", info->name);
+    printf("命令行: %s\n", info->cmdline);
+    printf("Exe (argv[0]): %s\n", info->exe);
+    printf("Exe路径: %s\n", info->exepath);
+    printf("当前工作目录: %s\n", info->cwd);
+    printf("参数: %s\n", info->args);
+    printf("状态: %d\n", info->state);
+    printf("是否存活: %s\n", info->is_alive ? "是" : "否");
+    printf("是否富化: %s\n", info->is_rich ? "是" : "否");
+    printf("虚拟内存: %lu bytes\n", info->vsize);
+    printf("驻留内存: %lu bytes\n", info->rss);
+    printf("===============\n\n");
+}
+
+int main() {
+    printf("测试进程缓存实现\n");
+    
+    // 初始化进程缓存
+    if (linx_process_cache_init() != 0) {
+        printf("进程缓存初始化失败\n");
+        return -1;
+    }
+    
+    // 测试获取当前进程信息
+    pid_t current_pid = getpid();
+    printf("获取当前进程信息 (PID: %d)\n", current_pid);
+    
+    linx_process_info_t *info = linx_process_cache_get(current_pid);
+    print_process_info(info);
+    
+    // 测试获取父进程信息
+    pid_t parent_pid = getppid();
+    printf("获取父进程信息 (PID: %d)\n", parent_pid);
+    
+    linx_process_info_t *parent_info = linx_process_cache_get(parent_pid);
+    print_process_info(parent_info);
+    
+    // 清理
+    linx_process_cache_deinit();
+    
+    return 0;
+}

--- a/userspace/linx_process_cache/include/linx_process_cache.h
+++ b/userspace/linx_process_cache/include/linx_process_cache.h
@@ -22,6 +22,8 @@ void linx_process_cache_deinit(void);
 
 linx_process_info_t *linx_process_cache_get(pid_t pid);
 
+linx_process_info_t *linx_process_cache_get_or_create(pid_t pid);
+
 int linx_process_cache_get_all(linx_process_info_t **list, int *count);
 
 int linx_process_cache_update_async(pid_t pid);

--- a/userspace/linx_process_cache/include/linx_process_cache_info.h
+++ b/userspace/linx_process_cache/include/linx_process_cache_info.h
@@ -23,18 +23,22 @@
  * tty  进程的控制终端。对于没有终端的进程，该值为0
 */
 typedef struct {
-    pid_t pid;                          /* 进程ID */
-    pid_t ppid;                         /* 父进程ID */
-    pid_t pgid;                         /* 进程组ID */
-    pid_t sid;                          /* 会话ID */
-    pid_t uid;                          /* 用户ID */
-    pid_t gid;                          /* 组ID */
+    pid_t pid;                              /* 进程ID */
+    pid_t ppid;                             /* 父进程ID */
+    pid_t pgid;                             /* 进程组ID */
+    uint32_t sid;                           /* 会话ID */
+    uint32_t uid;                           /* 用户ID */
+    uint32_t gid;                           /* 组ID */
+    uint32_t tty;                           /* tty */
+    uint32_t loginuid;                      /*  */
+    uint64_t cmdnargs;                      /* 命令行参数个数 */
 
-    char name[PROC_COMM_MAX_LEN];       /* 进程名 */
-    char comm[PROC_COMM_MAX_LEN];       
-    char cmdline[PROC_CMDLINE_LEN];     /* 命令行 */
-    char exe[PROC_PATH_MAX_LEN];        /* 进程执行文件路径 */
-    char cwd[PROC_PATH_MAX_LEN];        /* 当前工作目录 */
+    char name[PROC_COMM_MAX_LEN];           /* 进程名 读取 task->comm 或 /proc/pid/comm */
+    char cmdline[PROC_CMDLINE_LEN];         /* name + args */
+    char exe[PROC_PATH_MAX_LEN];            /* argv[0] 读取 /proc/pid/cmdline */
+    char exepath[PROC_PATH_MAX_LEN];        /* 进程的完整可执行路径 读取 /proc/pid/exe */
+    char cwd[PROC_PATH_MAX_LEN];            /* 当前工作目录 */
+    char args[4096];                        /*  不包括argv[0] */
 
     linx_process_state_t state;
     int nice;                           /* nice 值 */


### PR DESCRIPTION
Fix `linx_process_cache_get` to properly add newly created entries to the process cache and add `linx_process_cache_get_or_create`.

The original `linx_process_cache_get` created new `linx_process_info_t` objects when a PID was not found but did not add them to the `g_process_cache->hash_table`. This resulted in repeated lookup failures for the same PID and memory leaks. The updated function now correctly adds these entries using a write lock and a double-check mechanism for thread safety. A new function `linx_process_cache_get_or_create` is also introduced with the same logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-16222d4f-17d8-412c-b9b2-78d98e40c3f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-16222d4f-17d8-412c-b9b2-78d98e40c3f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

