### PR TITLE
Debug malloc error in read_proc_fd_info

### DIFF
--- a/userspace/linx_process_cache/linx_fd_info.c
+++ b/userspace/linx_process_cache/linx_fd_info.c
@@ -157,22 +157,22 @@ linx_fd_info_t *linx_fd_info_create(pid_t pid, int64_t fd)
         net_ns = sb.st_ino;
     }
 
-	snprintf(path, PROC_PATH_MAX_LEN, "/proc/%d/fd/%ld", pid, fd);
+		 snprintf(path, PROC_PATH_MAX_LEN, "/proc/%d/fd/%ld", pid, fd);
 
-	if (-1 == stat(path, &sb)) {
-		return NULL;	
-    }
+	 if (-1 == stat(path, &sb)) {
+	 	 return NULL;	
+	     }
 
-	fd_info = calloc(1, sizeof(fd_info));
-	if (!fd_info) {
-		return NULL;
-	}
+	 fd_info = calloc(1, sizeof(linx_fd_info_t));
+	 if (!fd_info) {
+	 	 return NULL;
+	 	}
 
-	fd_info->num = fd;
+	 fd_info->num = fd;
 
-	handle_file(path, &sb, net_ns, pid, fd_info);
+	 handle_file(path, &sb, net_ns, pid, fd_info);
 
-    return fd_info;
+	     return fd_info;
 }
 
 void linx_fd_info_destroy(linx_fd_info_t *fd_info)

--- a/userspace/linx_process_cache/linx_process_cache.c
+++ b/userspace/linx_process_cache/linx_process_cache.c
@@ -263,9 +263,9 @@ static int read_proc_exepath(pid_t pid, linx_process_info_t *info)
     snprintf(path, sizeof(path), "/proc/%d/exe", pid);
     len = readlink(path, info->exepath, PROC_PATH_MAX_LEN - 1);
     if (len > 0) {
-        info->exe[len] = '\0';
+        info->exepath[len] = '\0';
     } else {
-        info->exe[0] = '\0';
+        info->exepath[0] = '\0';
     }
     
     return (len > 0) ? 0 : -1;
@@ -308,7 +308,9 @@ static int read_proc_fd_info(pid_t pid, linx_process_info_t *info)
 
     /* 这里需要一个配置来确定读取文件的最大个数 */
     while ((entry = readdir(dir)) != NULL) {
-        sscanf(entry->d_name, "%ld", &fd);
+        if (sscanf(entry->d_name, "%ld", &fd) != 1) {
+            continue;
+        }
 
         fdi = linx_fd_info_create(pid, fd);
         if (!fdi) {


### PR DESCRIPTION
Fix `malloc(): corrupted top size` by correcting `linx_fd_info_t` memory allocation size.

The `malloc(): corrupted top size` error at `HASH_ADD_INT64` was caused by `linx_fd_info_create` allocating `sizeof(fd_info)` (pointer size) instead of `sizeof(linx_fd_info_t)`, leading to an undersized buffer. This resulted in heap metadata corruption when `uthash` wrote to the `hh` field. This PR also includes minor fixes for `read_proc_exepath` null termination and `read_proc_fd_info` directory entry parsing.

---
<a href="https://cursor.com/background-agent?bcId=bc-df7c6509-5e26-4fc9-9c7a-df34ea64cdd5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df7c6509-5e26-4fc9-9c7a-df34ea64cdd5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

